### PR TITLE
Fix history fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added `timezone` config to allow configuring the timezone according to which end-of-day is calculated.
 
 ## Other changes
-- TBD
+- Fixed `--resetdatabase` (broken in 1.6.1)
 
 # 1.6.1
 

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -269,7 +269,7 @@ try:
             info('Resetting database')
             delete_api = influx2.delete_api()
             start = '1970-01-01T00:00:00Z'
-            stop = startupTime.isoformat(timespec='seconds') + 'Z'
+            stop = startupTime.isoformat(timespec='seconds').replace("+00:00", "") + 'Z'
             delete_api.delete(start, stop, '_measurement="energy_usage"', bucket=bucket, org=org)
     else:
         info('Using InfluxDB version 1')


### PR DESCRIPTION
After https://github.com/jertel/vuegraf/commit/ea9f9f0afdd801eba9ae85bc8bd9aff0afabf8a5, `startupTime` has a `timezone` != `None` which per spec means that the offset will be included in the generated string: https://docs.python.org/3/library/datetime.html#datetime.datetime.isoformat.

Emporia doesn't accept this format, so this MR hackishly removes it. It's quite a dirty fix - the only alternative I am aware of involes creating an identical object with tz=None, but that would run into deprecated methods.